### PR TITLE
Extended cleaning functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,46 @@
 'use strict';
 var isPlainObject = require('is-plain-object');
 function clean(obj) {
-	return Object.keys(obj).reduce(function (result, key) {
-		if (obj[key] === null || obj[key] === undefined) {
-			return result;
-		}
-
-		if (isPlainObject(obj[key])) {
-			var res = clean(obj[key]);
-
-			if (Object.keys(res).length > 0) {
-				result[key] = res;
+	if (obj && isPlainObject(obj)) {
+		return Object.keys(obj).reduce(function (result, key) {
+			if (obj[key] === null || obj[key] === undefined) {
+				return result;
 			}
-		} else if (obj[key] !== '') {
-			result[key] = obj[key];
-		}
 
-		return result;
-	}, {});
+			if (isPlainObject(obj[key])) {
+				var res = clean(obj[key]);
+
+				if (Object.keys(res).length > 0) {
+					result[key] = res;
+				}
+			} else if (obj[key].constructor === Array) {
+				var cleanedArray = obj[key].map(function (el) {
+					return clean(el);
+				}).filter(function (ea) {
+					return ea !== undefined;
+				});
+				if (cleanedArray.length) {
+					result[key] = cleanedArray;
+				}
+			} else if (obj[key] !== '') {
+				result[key] = obj[key];
+			}
+
+			return result;
+		}, {});
+	} else if (obj.constructor === Array) {
+		return obj.map(function (ea) {
+			return clean(ea);
+		}).filter(function (ea) {
+			return ea !== undefined;
+		});
+	} else if (typeof obj === 'string') {
+		if (obj.length) {
+			return obj;
+		}
+	} else if (typeof obj === 'number' && !isNaN(obj)) {
+		return obj;
+	}
 }
 
 module.exports = clean;

--- a/test.js
+++ b/test.js
@@ -9,7 +9,13 @@ test('shallow', t => {
 	t.same(fn({foo: 'bar', baz: null}), {foo: 'bar'});
 	t.same(fn({foo: ''}), {});
 	t.same(fn({foo: 'bar', baz: ''}), {foo: 'bar'});
-	t.end();
+	t.same(fn(['foo', '']), ['foo']);
+	t.same(fn([]), []);
+	t.same(fn(''), undefined);
+	t.same(fn(0), 0);
+	t.same(fn(1), 1);
+	t.same(fn(parseInt("")), undefined);
+	t.same(fn(parseInt("1")), 1);
 });
 
 test('deep', t => {
@@ -22,5 +28,6 @@ test('deep', t => {
 	t.same(fn({foo: {bar: 'baz', baz: ''}}), {foo: {bar: 'baz'}});
 	t.same(fn({foo: {bar: 'baz', baz: {}}}), {foo: {bar: 'baz'}});
 	t.same(fn({foo: {bar: 'baz', baz: {bar: 'baz', baz: ''}}}), {foo: {bar: 'baz', baz: {bar: 'baz'}}});
-	t.end();
+	t.same(fn({foo: ['foo', '']}), {foo: ['foo']});
+	t.same(fn({foo: ['foo', ['bar', '']]}), {foo: ['foo', ['bar']]});
 });


### PR DESCRIPTION
- Removing empty strings from arrays
- Removing empty strings
- Handling stings, numbers and arrays explicitly

I was adding this additional functionality because it fits a use-case where I need this kind of cleaning behaviour. If it's not sufficiently generic enough or doesn't fit your use-case I'm happy to fork this off if you prefer? 
